### PR TITLE
FIX: Campaign Name Numeric Ordering

### DIFF
--- a/api/campaign.py
+++ b/api/campaign.py
@@ -34,7 +34,8 @@ class CampaignListAPI(Resource):
         sorting = parse_list_of_tuple(query_params.get('sort'))
         database_query = build_query(['name'], query_params)
         query = get_database().database[Campaign.get_collection_name()] \
-            .find(database_query, {'reports': False})
+            .find(database_query, {'reports': False}) \
+            .collation({'locale': 'en_US', 'numericOrdering': True})
         if sorting:
             query.sort(build_sort(sorting))
         add_skip_and_limit(query, query_params)


### PR DESCRIPTION
Use numeric ordering for campaign name
<img width="1102" alt="Screen Shot 2021-08-12 at 9 51 35 AM" src="https://user-images.githubusercontent.com/32876823/129131151-2e1ea02b-47c0-477b-9aa1-048fbad4739b.png">
