### PR TITLE
Fix: Include links for releases, campaigns and reports

### DIFF
--- a/migration/migration.ipynb
+++ b/migration/migration.ipynb
@@ -204,6 +204,47 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b9350870-a56c-42d2-9f21-32aa7612a92a",
+   "metadata": {},
+   "source": [
+    "Sanetize release links"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "f8353cb6-487d-47af-987f-b488b0d2f275",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "LINKS_REGEX = r\"(\\[([\\d+][\\.\\d+]*)\\]\\s)?(https?://[-|_|A-Z|a-z|.|/|0-9]+)\"\n",
+    "link_regex = re.compile(LINKS_REGEX)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "57da2084-0ae2-45e3-b87e-8acf7cc2a387",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "def sanetize_links(content: str, pattern: re.Pattern = link_regex):\n",
+    "    links: str = \"\"\n",
+    "    default: str = \"No links provided\"\n",
+    "    links_content = pattern.findall(content)\n",
+    "    for link in links_content:\n",
+    "        links += f\"{link[0]} {link[2]} \\n\"\n",
+    "    if not links:\n",
+    "        return default\n",
+    "    return links"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "ca117b0b-ed31-4f02-856c-87c8202acffb",
    "metadata": {},
    "source": [
@@ -212,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 10,
    "id": "a048e100-fb6c-4ee1-99c1-886193f6d4de",
    "metadata": {
     "tags": []
@@ -225,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "e12c2cd4-9416-4240-a5cf-1717a551d371",
    "metadata": {
     "tags": []
@@ -267,7 +308,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 12,
    "id": "5cfea8c2-ab8f-4bf1-b0e0-4445ab7dc9a7",
    "metadata": {
     "tags": []
@@ -302,7 +343,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "b10c02d0-529a-4b3e-a20c-f794d49874d8",
    "metadata": {
     "tags": []
@@ -330,7 +371,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "8f0afa06-88b5-4e77-a94a-f6d435481a01",
    "metadata": {
     "tags": []
@@ -374,7 +415,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "f1e7d551-c48d-4460-82fc-25a14c52fc5f",
    "metadata": {
     "tags": []
@@ -396,7 +437,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "962173bf-096d-4b7c-a4bb-a69aeeb8eb99",
    "metadata": {
     "tags": []
@@ -417,7 +458,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "50c6409c-1a32-4147-82a1-a8abb3c65a69",
    "metadata": {
     "tags": []
@@ -438,7 +479,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "6d3eb3ec-151b-42b5-b67f-ace3e7d247ba",
    "metadata": {
     "tags": []
@@ -462,7 +503,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "18e241b6-990f-446c-8b02-3196f5c0f616",
    "metadata": {
     "tags": []
@@ -490,7 +531,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "id": "be84ef81-e9ea-44a5-8448-cba27f15efaa",
    "metadata": {
     "tags": []
@@ -611,7 +652,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "id": "f04ae3e5-899e-403c-b0d3-9a7a2c5735b7",
    "metadata": {},
    "outputs": [],
@@ -633,7 +674,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "id": "baf22b79-749e-406f-91fa-427f5ede8a8e",
    "metadata": {
     "tags": []
@@ -653,7 +694,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 23,
    "id": "2e91bac6-6fd0-4350-b0f7-a3d9fe8175c2",
    "metadata": {
     "tags": []
@@ -673,7 +714,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 24,
    "id": "f2c142cd-840a-4c5a-97df-8ec4ba8e8ec9",
    "metadata": {
     "tags": []
@@ -693,7 +734,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 25,
    "id": "a44f12eb-c5c0-4500-a14d-2009b6cb67a4",
    "metadata": {
     "tags": []
@@ -711,7 +752,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 26,
    "id": "43c56a93-ae26-48da-b78f-51c3b397b15e",
    "metadata": {},
    "outputs": [
@@ -719,7 +760,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Elapsed time: 0:00:21.206364\n"
+      "Elapsed time: 0:00:21.383938\n"
      ]
     }
    ],
@@ -737,7 +778,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 27,
    "id": "0f8b0674-7e6a-4ece-9c4b-421d5add1505",
    "metadata": {
     "tags": []
@@ -757,7 +798,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 28,
    "id": "6eeabbee-1b7f-4db1-8d2d-a48272ab8624",
    "metadata": {
     "tags": []
@@ -769,7 +810,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 29,
    "id": "0e1ef29e-4bab-4d32-b8f8-45d50c0dc5dc",
    "metadata": {
     "tags": []
@@ -795,7 +836,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 30,
    "id": "e0221d66-ff2c-411d-8eaa-d0dc28850563",
    "metadata": {
     "tags": []
@@ -821,7 +862,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 31,
    "id": "063e8a39-b1b8-4831-a72d-e333b73cb5da",
    "metadata": {
     "tags": []
@@ -871,7 +912,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 32,
    "id": "eb56340c-c58e-4a77-8a78-0622c3730962",
    "metadata": {
     "tags": []
@@ -891,7 +932,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 33,
    "id": "79feb546-e7de-4377-8748-60926fcd7a28",
    "metadata": {
     "tags": []
@@ -901,7 +942,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Elapsed time: 0:00:02.014581\n"
+      "Elapsed time: 0:00:56.658002\n"
      ]
     }
    ],
@@ -925,7 +966,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 34,
    "id": "af78de38-1514-4c1c-8f39-85bfd83dd4d8",
    "metadata": {
     "tags": []
@@ -959,7 +1000,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 35,
    "id": "4f866671-069d-4974-a913-c9455974efb7",
    "metadata": {
     "tags": []
@@ -975,7 +1016,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 36,
    "id": "9da93c88-7e0e-45de-a033-2b441bea4d2c",
    "metadata": {
     "tags": []
@@ -1007,7 +1048,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 37,
    "id": "8d28a9b1-6dbb-4076-9513-bc9b6e082e10",
    "metadata": {
     "tags": []
@@ -1019,7 +1060,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 38,
    "id": "990573e7-56c7-4359-b37f-059878ba5a96",
    "metadata": {
     "tags": []
@@ -1051,7 +1092,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 39,
    "id": "27e0fc46-f3c1-44fe-982d-e910c4855c51",
    "metadata": {
     "tags": []
@@ -1073,7 +1114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 40,
    "id": "84bf50f9-843e-4019-9cfd-2e620f5d7f2d",
    "metadata": {
     "tags": []
@@ -1093,7 +1134,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 41,
    "id": "90fd94a5-d38a-47e5-9331-3ac418820368",
    "metadata": {
     "tags": []
@@ -1115,7 +1156,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 42,
    "id": "47bfdadc-5e51-4e0e-a3a4-c08fb0489ebb",
    "metadata": {},
    "outputs": [
@@ -1123,7 +1164,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Elapsed time: 0:00:00.302449\n"
+      "Elapsed time: 0:00:08.369541\n"
      ]
     }
    ],
@@ -1147,7 +1188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 43,
    "id": "d3828b3b-4985-4aaa-bfe8-f607327cc483",
    "metadata": {
     "tags": []
@@ -1189,7 +1230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 44,
    "id": "5384db21-7315-42a8-a606-2214ada4cef7",
    "metadata": {},
    "outputs": [],
@@ -1203,7 +1244,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 45,
    "id": "b23c149a-9ba7-47be-9aef-186aad35a389",
    "metadata": {
     "tags": []
@@ -1223,7 +1264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 46,
    "id": "8094c892-6892-4822-a7c8-519aef73e715",
    "metadata": {
     "tags": []
@@ -1244,7 +1285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 47,
    "id": "d56286d3-e6eb-4d2e-8887-aab8fa7e5503",
    "metadata": {
     "tags": []
@@ -1265,7 +1306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 48,
    "id": "7fa65efc-e6c0-4b7a-9105-7c39f181b8fd",
    "metadata": {},
    "outputs": [],
@@ -1282,7 +1323,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 49,
    "id": "2aaa6962-4eb4-4608-82ce-ffc0f082e931",
    "metadata": {},
    "outputs": [
@@ -1290,7 +1331,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Elapsed time: 0:01:20.596891\n"
+      "Elapsed time: 0:01:20.759665\n"
      ]
     }
    ],
@@ -1308,7 +1349,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 50,
    "id": "57a12edc-646f-4549-83e5-aba5b7810512",
    "metadata": {
     "tags": []
@@ -1328,7 +1369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 51,
    "id": "7701e285-ec2c-4100-90e0-5cd73c6c9c9d",
    "metadata": {
     "tags": []
@@ -1355,7 +1396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 52,
    "id": "85702058-dd3d-4552-b41d-7cb397a96530",
    "metadata": {
     "tags": []
@@ -1381,7 +1422,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 53,
    "id": "c198a7e8-bd31-4401-8c8f-cbfb97ee4b03",
    "metadata": {
     "tags": []
@@ -1393,7 +1434,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 54,
    "id": "3283fe15-7ad5-4537-88a3-3c439743dea0",
    "metadata": {
     "tags": []
@@ -1419,7 +1460,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 55,
    "id": "aed87de1-356b-4e9c-9e9d-956a27c05efd",
    "metadata": {
     "tags": []
@@ -1439,7 +1480,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 56,
    "id": "aa7a0b7e-bbb6-43de-94bd-2a4c8daf7eff",
    "metadata": {
     "tags": []
@@ -1459,7 +1500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 58,
    "id": "051c0282-ae00-4b23-8b85-023e5695f4b3",
    "metadata": {
     "tags": []
@@ -1521,8 +1562,8 @@
     "            # If STATUS_KIND == SUMMARY, this release has the description for the campaign\n",
     "            # Do not persist it as a report            \n",
     "            comments = row[\"comments\"] if row[\"comments\"] else \"No comments provided\"\n",
-    "            links = row[\"links\"] if row[\"links\"] else \"No links provided\"\n",
-    "            links = \"\\n\".join([])\n",
+    "            links = row[\"links\"] if row[\"links\"] else \"\"\n",
+    "            links = sanetize_links(content=links)\n",
     "            author_not_found_inside_ldap = f\"Author: {author_name}\" if not author_email else \"\"\n",
     "            \n",
     "            if status_kind == \"SUMMARY\":\n",
@@ -1568,7 +1609,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": 59,
    "id": "13bf28d6-7590-4640-a3c4-cb13679aea62",
    "metadata": {
     "tags": []
@@ -1589,7 +1630,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": 60,
    "id": "a4f6c9dd-e491-4471-a3a2-bb96a52a308a",
    "metadata": {
     "tags": []
@@ -1599,7 +1640,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Elapsed time: 0:01:37.564129\n"
+      "Elapsed time: 0:09:44.454339\n"
      ]
     }
    ],
@@ -1629,7 +1670,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": 61,
    "id": "1e54398b-a71e-4f05-8bec-e19a454325b0",
    "metadata": {
     "tags": []
@@ -1639,7 +1680,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Elapsed time: 0:01:37.590052\n"
+      "Elapsed time: 0:09:44.485365\n"
      ]
     }
    ],


### PR DESCRIPTION
The links were set only as a empty string. Now, there is a regex to parse them