### PR TITLE
Increase the maximum number of campaigns to compare

### DIFF
--- a/api/campaign.py
+++ b/api/campaign.py
@@ -2,6 +2,7 @@
 Campaign API
 """
 import os
+import multiprocessing
 import numpy
 from copy import deepcopy
 from flask.globals import request, session
@@ -15,6 +16,7 @@ from utils.user import require_permission
 from utils.request import parse_list_of_tuple
 from utils.logger import api_logger
 from utils.cache import MemoryCache
+from utils.group import compute_progress_category
 from core.database import get_database
 from core import Namespace
 from models.campaign import Campaign
@@ -216,7 +218,7 @@ class CampaignReportComparison(Resource):
     to compare the reports progress.
     """
 
-    MAXIMUM_FOR_COMPARISON: int = 10
+    MAXIMUM_FOR_COMPARISON = 35
 
     def get(self):
         search_by: str = request.args.get("search", "")
@@ -251,10 +253,8 @@ class CampaignReportComparison(Resource):
                 by name.
         """
         only_subset: bool = False
-        campaigns: list[Campaign] = self.__get_campaigns_comparison(search=search)
-        total_campaigns: int = len(campaigns)
+        campaigns, total_campaigns = self.__get_campaigns_comparison(search=search)
         if total_campaigns > self.MAXIMUM_FOR_COMPARISON:
-            campaigns = campaigns[:self.MAXIMUM_FOR_COMPARISON]
             only_subset = True
 
         grouped: dict = self.__group_campaigns_reports(campaigns=campaigns)
@@ -268,7 +268,7 @@ class CampaignReportComparison(Resource):
         }
         return result
 
-    def __get_campaigns_comparison(self, search: str) -> list[Campaign]:
+    def __get_campaigns_comparison(self, search: str) -> tuple[list[Campaign], int]:
         """
         Retrieve the information related to all the campaigns
         whose name matches the regex given
@@ -277,20 +277,24 @@ class CampaignReportComparison(Resource):
             search (str): Regex to filter the desired campaigns
                 by name.
         Returns:
-            list[Campaign]: Related campaigns.
+            list[Campaign], int: Related campaigns and total size .
         """
         database_query = build_query(["name"], {"search": search})
+        cursor = get_database().database[Campaign.get_collection_name()]
+
+        # Total size without limits
+        total_size = cursor.count_documents(database_query)
         campaign_query_result = (
-            get_database()
-            .database[Campaign.get_collection_name()]
+            cursor
             .find(database_query, {"reports": False})
+            .limit(self.MAXIMUM_FOR_COMPARISON)
             .collation({"locale": "en_US", "numericOrdering": True})
         )
         campaigns: Campaign = [
             Campaign.get_by_name(result.get("name"))
             for result in campaign_query_result
         ]
-        return campaigns
+        return campaigns, total_size
     
     def __group_campaigns_reports(self, campaigns: list[Campaign]) -> dict:
         """
@@ -333,96 +337,6 @@ class CampaignReportComparison(Resource):
         
         return category
 
-    def __get_progress_matrix(
-            self, 
-            category: str,
-            subcategory: str,
-            subcategory_reports: dict
-        ) -> dict:
-        """
-        Compute a matrix to display the report's progress for all the
-        campaigns included into a subcategories. 
-        Moreover, include some metadata with statistics of interest.
-
-        Args:
-            category (str): Comparison category
-            subcategory (str): Comparison subcategory
-            subcategory_reports (dict): The information for the
-                subcategory, the campaigns included for the comparison
-                and the campaign status per each group.
-        Returns:
-            dict: The campaign progress per each group included in the
-                subcategory and some statistics about this content. 
-        """
-        campaigns_raw: dict = subcategory_reports.pop("campaigns_subcategory")
-        campaigns: list[str] = list(campaigns_raw.keys())
-        subcategory_groups: list[str] = group[category][subcategory]
-        total_reports: int = len(subcategory_groups) * len(campaigns)
-
-        # Count by report's status
-        by_status: dict[int, int] = dict(
-            zip(
-                REPORT_STATUS_LABEL.keys(), 
-                [0] * len(REPORT_STATUS_LABEL)
-            )
-        )
-        by_status[ReportStatus.NOT_YET_DONE] = total_reports
-
-        # Some statistics
-        metadata: dict = {
-            "total_reports": total_reports,
-            "total_filled": 0,
-            "per_status": by_status
-        }
-
-        # Create a default matrix: Groups X Campaigns
-        progress_matrix = numpy.full(
-            shape=(len(campaigns), len(subcategory_groups)),
-            fill_value=ReportStatus.NOT_YET_DONE.value,
-            dtype=int
-        )
-
-        # Fill the matrix
-        for group_name, statuses in subcategory_reports.items():
-            try:
-                group_idx = subcategory_groups.index(group_name)
-            except ValueError:
-                continue
-
-            for report_status in statuses:
-                campaign_name = report_status["campaign"]
-                status = report_status["status"]
-                campaign_idx = campaigns.index(campaign_name)
-
-                if status != ReportStatus.NOT_YET_DONE.value:
-                    # Update the matrix
-                    progress_matrix[campaign_idx][group_idx] = status
-
-                    # Update the metadata
-                    metadata["total_filled"] += 1
-                    by_status[ReportStatus.NOT_YET_DONE] -= 1
-                    as_report_status = ReportStatus(status)
-                    by_status[as_report_status] += 1
-
-        # Parse the report's category index
-        by_status_parsed = {}
-        for key, value in by_status.items():
-            by_status_parsed[key.value] = value
-        metadata["per_status"] = by_status_parsed
-
-        # Parse as a standard list
-        progress_matrix = progress_matrix.tolist()
-
-        progress_result: dict = {
-            "progress": progress_matrix,
-            "metadata": metadata,
-            "campaigns": campaigns,
-            "groups": subcategory_groups,
-            "category": category,
-            "subcategory": subcategory
-        }
-        return progress_result
-
     def __compute_progress(self, grouped: dict) -> dict:
         """
         Computes the progress for for each category and
@@ -435,24 +349,13 @@ class CampaignReportComparison(Resource):
             dict: Report's progress per each category and subcategory.
         """
         result = {}
-        for category, subcategories in grouped.items():
-            subcategories_data = {}
-            for subcategory, status in subcategories.items():
-                # Check the category and subcategory matches
-                if group.get(category, {}).get(subcategory) is None:
-                    _logger.warning(
-                        "Category (%s) or subcategory (%s) not available in default groups",
-                        category, subcategory
-                    )
-                    continue
-                progress = self.__get_progress_matrix(
-                    category=category, 
-                    subcategory=subcategory,
-                    subcategory_reports=status
-                )
-                subcategories_data[subcategory] = progress
-            
-            result[category] = subcategories_data
-        
+        with multiprocessing.Pool() as pool:
+            result_categories = pool.starmap(func=compute_progress_category, iterable=grouped.items())
+
+        try:
+            result = dict(result_categories)
+        except Exception as e:
+            _logger.error("Unable to compute the progress matrix: %s", e)
+
         return result
     

--- a/react_frontend/src/components/CampaignReportProgress.tsx
+++ b/react_frontend/src/components/CampaignReportProgress.tsx
@@ -229,7 +229,49 @@ const CategoryReportList = (
   { category, data }: { category: string, data: ReportComparison }
 ): ReactElement => {
   const [expanded, setExpanded] = useState<boolean>(false);
+  const [subcategoryList, setSubcategoryList] = useState<ReactElement[]>([]);
   const categoryData: SubcategoryComparison = data.categories[category];
+
+  useEffect(() => {
+    if (!expanded || subcategoryList.length > 0) {
+      return;
+    }
+
+    let isMounted = true;
+    const renderElements = async () => {
+      try {
+        const result = await Promise.all(renderAllSubCategories(categoryData));
+        if (isMounted) {
+          setSubcategoryList(result);
+        }
+      }
+      catch (err) {
+        console.error("Unable to render subcategories: ", err);
+      }
+    };
+
+    renderElements();
+
+    return () => {
+      isMounted = false;
+    }
+  }, [expanded, categoryData, subcategoryList.length]);
+
+  const renderAllSubCategories = (data: SubcategoryComparison): Promise<ReactElement>[] => {
+    return Object.keys(data).map((subcategory, index) => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve(
+            <SubcategoryList
+              subcategory={subcategory}
+              index={index}
+              data={data}
+            />
+          );
+        }, 0);
+      });
+    });
+  };
 
   return (
     <Accordion expanded={expanded} onChange={(e, isExpanded) => { setExpanded(isExpanded) }}>
@@ -237,13 +279,7 @@ const CategoryReportList = (
         <strong>{category}</strong>
       </AccordionSummary>
       <AccordionDetails style={{ padding: '0 1rem', display: 'block' }}>
-        {Object.keys(categoryData).map((subcategory, index) =>
-          <SubcategoryList
-            subcategory={subcategory}
-            index={index}
-            data={categoryData}
-          />
-        )}
+        {!subcategoryList.length ? <p>Loading comparison for category {category}</p>: subcategoryList}
       </AccordionDetails>
     </Accordion>
   );

--- a/utils/group.py
+++ b/utils/group.py
@@ -2,8 +2,119 @@
 Group data util
 '''
 
+import numpy
+
+from data.group import group
+from models.report import REPORT_STATUS_LABEL, ReportStatus
+from utils.logger import api_logger as _logger
+
+
 def get_subcategory_from_group(group_path):
     '''
     Get subcategory string from group path string
     '''
     return '.'.join(group_path.split('.')[:2])
+
+
+def get_progress_matrix(*args) -> dict:
+    """
+    Compute a matrix to display the report's progress for all the
+    campaigns included into a subcategories.
+    Moreover, include some metadata with statistics of interest.
+
+    Args:
+        category (str): Comparison category
+        subcategory (str): Comparison subcategory
+        subcategory_reports (dict): The information for the
+            subcategory, the campaigns included for the comparison
+            and the campaign status per each group.
+    Returns:
+        dict: The campaign progress per each group included in the
+            subcategory and some statistics about this content.
+    """
+    category, subcategory, subcategory_reports = args
+    campaigns_raw: dict = subcategory_reports.pop("campaigns_subcategory")
+    campaigns: list[str] = list(campaigns_raw.keys())
+    subcategory_groups: list[str] = group[category][subcategory]
+    total_reports: int = len(subcategory_groups) * len(campaigns)
+
+    # Count by report's status
+    by_status: dict[int, int] = dict(
+        zip(REPORT_STATUS_LABEL.keys(), [0] * len(REPORT_STATUS_LABEL))
+    )
+    by_status[ReportStatus.NOT_YET_DONE] = total_reports
+
+    # Some statistics
+    metadata: dict = {
+        "total_reports": total_reports,
+        "total_filled": 0,
+        "per_status": by_status,
+    }
+
+    # Create a default matrix: Groups X Campaigns
+    progress_matrix = numpy.full(
+        shape=(len(campaigns), len(subcategory_groups)),
+        fill_value=ReportStatus.NOT_YET_DONE.value,
+        dtype=int,
+    )
+
+    # Fill the matrix
+    for group_name, statuses in subcategory_reports.items():
+        try:
+            group_idx = subcategory_groups.index(group_name)
+        except ValueError:
+            continue
+
+        for report_status in statuses:
+            campaign_name = report_status["campaign"]
+            status = report_status["status"]
+            campaign_idx = campaigns.index(campaign_name)
+
+            if status != ReportStatus.NOT_YET_DONE.value:
+                # Update the matrix
+                progress_matrix[campaign_idx][group_idx] = status
+
+                # Update the metadata
+                metadata["total_filled"] += 1
+                by_status[ReportStatus.NOT_YET_DONE] -= 1
+                as_report_status = ReportStatus(status)
+                by_status[as_report_status] += 1
+
+    # Parse the report's category index
+    by_status_parsed = {}
+    for key, value in by_status.items():
+        by_status_parsed[key.value] = value
+    metadata["per_status"] = by_status_parsed
+
+    # Parse as a standard list
+    progress_matrix = progress_matrix.tolist()
+
+    progress_result: dict = {
+        "progress": progress_matrix,
+        "metadata": metadata,
+        "campaigns": campaigns,
+        "groups": subcategory_groups,
+        "category": category,
+        "subcategory": subcategory,
+    }
+    return progress_result
+
+
+def compute_progress_category(*args) -> tuple[str, dict]:
+    """Computes the progress for a given category."""
+    subcategories_data = {}
+    category, subcategories = args
+    for subcategory, status in subcategories.items():
+        # Check the category and subcategory matches
+        if group.get(category, {}).get(subcategory) is None:
+            _logger.warning(
+                "Category (%s) or subcategory (%s) not available in default groups",
+                category,
+                subcategory,
+            )
+            continue
+
+        progress = get_progress_matrix(category, subcategory, status)
+        subcategories_data[subcategory] = progress
+
+    return category, subcategories_data


### PR DESCRIPTION
Completes: #59 

Compare a maximum of 35 campaigns simultaneously. Optimize the web page rendering and the comparison matrix computation. The limit is set to that value because if it is higher, the browser will have issues rendering all the elements properly, making the web page crash.