### PR TITLE
Fix: Default order for compact view

### DIFF
--- a/api/campaign.py
+++ b/api/campaign.py
@@ -145,7 +145,9 @@ class CampaignGetAPI(Resource):
                 f"{category_subcategory}.{each_group}"
                 for each_group in group[category][subcategory]
             ]
-            groups = list(set(latest_groups).union(set(campaign_all_groups.get(category_subcategory, []))))
+            groups_campaign_category = set(campaign_all_groups.get(category_subcategory, []))
+            remaining_groups = list(groups_campaign_category.difference(set(latest_groups)))
+            groups = latest_groups + remaining_groups
             campaign_group[category]["subcategories"].append(
                 {
                     "name": subcategory,


### PR DESCRIPTION
Fixes: https://github.com/cms-PdmV/ValDB2/pull/61

The campaign's compact view requires a specific order in the array elements [1] to display another classification of elements. Append remaining groups (those that change in time) at the end of the list.

References:
[1] SplitGroup - Use in the campaign compact view: https://github.com/cms-PdmV/ValDB2/blob/779401cde36c17658af911a964ad2e74fe96b119/react_frontend/src/utils/constant.ts#L1